### PR TITLE
remove dependency on minifb::Window by refactoring `.draw` so that it…

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,4 +1,4 @@
-use chipotle8::{AsKeyboard, Interpreter, Key};
+use chipotle8::{AsKeyboard, Interpreter, Key, WIDTH, HEIGHT};
 use device_query::{DeviceQuery, DeviceState, Keycode};
 use minifb::{ScaleMode, Window, WindowOptions};
 use std::io::Error;
@@ -65,9 +65,18 @@ fn main() -> Result<(), Error> {
             chipotle8::TIMER_CYCLE_INTERVAL,
         ));
 
-        interpreter.cycle();
+        // execute the current operation and draw the display if it changed
+        if let Some(op) = interpreter.cycle() {
+            if op.is_display_op() {
+                let display = interpreter.get_pixels();
+                window
+                    .update_with_buffer(display, WIDTH, HEIGHT)
+                    .unwrap();
+            }
+        }
+
+        // check for key press changes and update the Interpreter with which keys are up or down
         interpreter.handle_key_input(&keyboard);
-        interpreter.draw(&mut window);
     }
     Ok(())
 }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,4 +1,4 @@
-use chipotle8::{AsKeyboard, Interpreter, Key, WIDTH, HEIGHT};
+use chipotle8::{AsKeyboard, Interpreter, Key, HEIGHT, WIDTH};
 use device_query::{DeviceQuery, DeviceState, Keycode};
 use minifb::{ScaleMode, Window, WindowOptions};
 use std::io::Error;
@@ -69,9 +69,7 @@ fn main() -> Result<(), Error> {
         if let Some(op) = interpreter.cycle() {
             if op.is_display_op() {
                 let display = interpreter.get_pixels();
-                window
-                    .update_with_buffer(display, WIDTH, HEIGHT)
-                    .unwrap();
+                window.update_with_buffer(display, WIDTH, HEIGHT).unwrap();
             }
         }
 

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -1,6 +1,5 @@
 //! A wrapper around a 64x32 bit buffer array that abstracts the Interpreter's display state
 
-use minifb::Window;
 use std::ops::Index;
 
 pub const WIDTH: usize = 64;
@@ -81,13 +80,16 @@ impl Graphics {
         }
     }
 
-    /// Draw the 64x32 bit buffer to a Window. We enlarge the 64x32 resolution by ENLARGE_RATIO
-    /// because otherwise the screen is far too small to view
-    pub fn draw(&mut self, window: &mut Window) {
-        // TODO don't hardcode window size. Make a Display struct that handles resizing
+    /// Returns the pixels for a 640 x 320 resolution display.
+    ///
+    /// TODO NOTE: Currently we enlarge the base 64x32 resolution by
+    /// ENLARGE_RATIO (currently equals 10) because otherwise the screen
+    /// is far too small to view. In the future we will make this performantly
+    /// dynamically updateable so users can resize their game windows.
+    pub fn get_pixels(&mut self) -> &[u32] {
 
         // TODO: nit: refactor looping logic so that it is more cache friendly. Right now
-        // we are jumping ahead in the array too much and thrashing the lowest level cache.
+        // we are jumping ahead in the array too much and thrashing the cache
         for y in 0..HEIGHT {
             let y_offset = y * WIDTH * ENLARGE_RATIO * ENLARGE_RATIO;
             for x in 0..WIDTH {
@@ -117,9 +119,7 @@ impl Graphics {
             }
         }
 
-        window
-            .update_with_buffer(&self.display, WIDTH * ENLARGE_RATIO, HEIGHT * ENLARGE_RATIO)
-            .unwrap();
+        &self.display
     }
 }
 

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -87,7 +87,6 @@ impl Graphics {
     /// is far too small to view. In the future we will make this performantly
     /// dynamically updateable so users can resize their game windows.
     pub fn get_pixels(&mut self) -> &[u32] {
-
         // TODO: nit: refactor looping logic so that it is more cache friendly. Right now
         // we are jumping ahead in the array too much and thrashing the cache
         for y in 0..HEIGHT {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,6 @@
 //! as WebAssembly
 use crate::graphics::Graphics;
 pub use crate::keyboard::Key;
-use minifb::Window;
 use op::Op;
 use rand::{thread_rng, Rng};
 use slog::debug;
@@ -453,18 +452,19 @@ impl Interpreter {
         self.pc += 2;
     }
 
-    /// Draw the 64x32 bit buffer to a Window.
-    pub fn draw(&mut self, window: &mut Window) {
-        if self.prev_op.is_none() || Self::is_display_op(self.prev_op.unwrap()) {
-            self.graphics.draw(window);
-        }
+    /// Returns the display pixels with a resolution of width by height.
+    pub fn get_pixels(&mut self) -> &[u32] {
+            self.graphics.get_pixels()
     }
 
-    /// step forward one cycle in the interpreter. A cycle consists of:
+    /// step forward one cycle in the interpreter. Returns Some(op) if an opcode was executed.
+    /// or None if we're in the blocking state waiting for a keyboard press.
+    ///
+    /// A cycle consists of:
     /// 1. read the instruction at the program counter
     /// 2. decode it
     /// 3. execute it
-    pub fn cycle(&mut self) {
+    pub fn cycle(&mut self) -> Option<Op> {
         let op = self.get_instr_at_pc();
         if !self.keyboard.is_blocking() {
             debug!(
@@ -501,16 +501,10 @@ impl Interpreter {
                 self.delay_timer,
                 self.sound_timer
             );
-        }
-    }
 
-    /// Return true if this op is related to the display. Later we use
-    /// this to decide if we should devote cycles to redrawing the graphics buffer
-    fn is_display_op(op: Op) -> bool {
-        match op {
-            Op::DispDraw(_, _, _) | Op::DispClear => true,
-            _ => false,
+            return Some(op);
         }
+        None
     }
 
     /// Return true if this operation is one of the many Ops for which we should

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -452,9 +452,11 @@ impl Interpreter {
         self.pc += 2;
     }
 
-    /// Returns the display pixels with a resolution of width by height.
+    /// Returns the display pixels with a resolution of 640x320
+    ///
+    /// TODO: do not hardcode the ENLARGE_RATIO.
     pub fn get_pixels(&mut self) -> &[u32] {
-            self.graphics.get_pixels()
+        self.graphics.get_pixels()
     }
 
     /// step forward one cycle in the interpreter. Returns Some(op) if an opcode was executed.

--- a/src/op.rs
+++ b/src/op.rs
@@ -73,6 +73,17 @@ pub enum Op {
     RegLoad(u8),
 }
 
+impl Op {
+    /// Return true if this op is related to the display. Later we use
+    /// this to decide if we should devote cycles to redrawing the graphics buffer
+    pub fn is_display_op(&self) -> bool {
+        match *self {
+            Op::DispDraw(_, _, _) | Op::DispClear => true,
+            _ => false,
+        }
+    }
+}
+
 impl From<u16> for Op {
     fn from(item: u16) -> Self {
         let mask = 0xF;


### PR DESCRIPTION
… returns the pixel array,

rather performing the update on Window. now any callers of `.get_pixels` (the new `.draw`) will use the return value to do the drawing
however they wish