### PR TITLE
spend some time improving the docs.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "chipotle8"
 version = "0.1.0"
 authors = ["Melvillian <melvillevt@gmail.com>"]
 edition = "2018"
+license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/README.md
+++ b/README.md
@@ -11,12 +11,15 @@ There are many CHIP-8 implementations, so this one differentiates itself by runn
 - [ ] Implement client library in Javascript (maybe some WASM thrown in for fun)
 - [ ] Play first networked Pong game!
 
-## Install
-`$> cargo build && cargo test`
-
 ## Usage
-Run the following command 
-`$> cargo run /path/to/chip8/game_file`
+```
+# Cargo.toml
+[dependencies]
+chipotle8 = { git = "https://github.com/Melvillian/chipotle8" }
+```
+
+## Example
+`$> cargo run --example pong`
 
 ## Acknowledgements
 The following guides and developers have been very helpful in inspiring me to learn about interpreters/emulators

--- a/examples/pong.rs
+++ b/examples/pong.rs
@@ -52,7 +52,7 @@ fn main() -> Result<(), Error> {
     window.limit_update_rate(Some(Duration::from_millis(16)));
 
     // create the interpreter and load the pong game file
-    let mut interpreter = crate::Interpreter::with_game_file(None, "data/PONG")?;
+    let mut interpreter = crate::Interpreter::with_game_file("data/PONG")?;
 
     // setup keyboard
     let device_state = DeviceState::new();

--- a/examples/pong.rs
+++ b/examples/pong.rs
@@ -17,18 +17,18 @@ impl AsKeyboard for Keyboard {
                 Keycode::Key2 => Some(Key::Key2),
                 Keycode::Key3 => Some(Key::Key3),
                 Keycode::Key4 => Some(Key::C),
-                Keycode::Q => Some(Key::Key4),
-                Keycode::W => Some(Key::Key5),
-                Keycode::E => Some(Key::Key6),
-                Keycode::R => Some(Key::D),
-                Keycode::A => Some(Key::Key7),
-                Keycode::S => Some(Key::Key8),
-                Keycode::D => Some(Key::Key9),
-                Keycode::F => Some(Key::E),
-                Keycode::Z => Some(Key::A),
-                Keycode::X => Some(Key::Key0),
-                Keycode::C => Some(Key::B),
-                Keycode::V => Some(Key::F),
+                Keycode::Q    => Some(Key::Key4),
+                Keycode::W    => Some(Key::Key5),
+                Keycode::E    => Some(Key::Key6),
+                Keycode::R    => Some(Key::D),
+                Keycode::A    => Some(Key::Key7),
+                Keycode::S    => Some(Key::Key8),
+                Keycode::D    => Some(Key::Key9),
+                Keycode::F    => Some(Key::E),
+                Keycode::Z    => Some(Key::A),
+                Keycode::X    => Some(Key::Key0),
+                Keycode::C    => Some(Key::B),
+                Keycode::V    => Some(Key::F),
                 _ => None,
             })
             .collect()
@@ -51,10 +51,8 @@ fn main() -> Result<(), Error> {
     // Limit to max update rate. This only needs about 60 Hz, which is 16ms
     window.limit_update_rate(Some(Duration::from_millis(16)));
 
-    let mut interpreter = crate::Interpreter::new(None);
-
-    // load the game file
-    interpreter.initialize("data/PONG").unwrap();
+    // create the interpreter and load the pong game file
+    let mut interpreter = crate::Interpreter::with_game_file(None, "data/PONG")?;
 
     // setup keyboard
     let device_state = DeviceState::new();

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -6,7 +6,7 @@ use std::iter::FromIterator;
 use std::rc::Rc;
 
 /// Key's variants are the 16 keys from the CHIP-8's hexadecimal keyboard.
-/// The recommended key mapping, based on the standard CHIP-8 emulator implementation is:
+/// The recommended key mapping, based on the standard CHIP-8 interpreter implementation is:
 ///
 /// ```text
 /// Keyboard              Keypad

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,7 @@
 //!     window.limit_update_rate(Some(Duration::from_millis(16)));
 //!
 //!     // create the interpreter and load the pong game file
-//!     let mut interpreter = crate::Interpreter::with_game_file(None, "data/PONG")?;
+//!     let mut interpreter = crate::Interpreter::with_game_file("data/PONG")?;
 //!
 //!     // setup keyboard
 //!     let device_state = DeviceState::new();
@@ -95,7 +95,7 @@
 //! ```
 use crate::graphics::Graphics;
 pub use crate::keyboard::Key;
-use op::Op;
+pub use op::Op;
 use rand::{thread_rng, Rng};
 use slog::debug;
 use slog::Logger;
@@ -133,13 +133,65 @@ mod op;
 #[cfg(test)]
 mod lib_test;
 
-/// Returns A Vec of [`Key`](enum.Key.html)s which are currently down on the system keyboard. See
-/// [`Key`](enum.Key.html) for the standard mapping for a QWERTY keyboard to CHIP-8's hexadecimal keyboard
+/// A trait for interfacing the user's chosen keyboard crate with `chipotle8`'s hexadecimal keyboard
+///
+/// # Examples
+///
+/// ```no_run
+/// use chipotle8::{AsKeyboard, Key};
+/// use device_query::{DeviceQuery, DeviceState, Keycode};
+///
+/// struct Keyboard(pub DeviceState);
+///
+/// impl AsKeyboard for Keyboard {
+///     fn keys_down(&self) -> Vec<Key> {
+///         self.0
+///             .get_keys()
+///             .iter()
+///             .filter_map(|key: &Keycode| match key {
+///                 Keycode::Key1 => Some(Key::Key1),
+///                 Keycode::Key2 => Some(Key::Key2),
+///                 Keycode::Key3 => Some(Key::Key3),
+///                 Keycode::Key4 => Some(Key::C),
+///                 Keycode::Q    => Some(Key::Key4),
+///                 Keycode::W    => Some(Key::Key5),
+///                 Keycode::E    => Some(Key::Key6),
+///                 Keycode::R    => Some(Key::D),
+///                 Keycode::A    => Some(Key::Key7),
+///                 Keycode::S    => Some(Key::Key8),
+///                 Keycode::D    => Some(Key::Key9),
+///                 Keycode::F    => Some(Key::E),
+///                 Keycode::Z    => Some(Key::A),
+///                 Keycode::X    => Some(Key::Key0),
+///                 Keycode::C    => Some(Key::B),
+///                 Keycode::V    => Some(Key::F),
+///                 _ => None,
+///             })
+///             .collect()
+///     }
+/// }
 pub trait AsKeyboard {
+    /// Returns A Vec of [`Key`](enum.Key.html)s which are currently down on the system keyboard. See
+    /// [`Key`](enum.Key.html) for the suggested mapping for a QWERTY keyboard to CHIP-8's hexadecimal
+    /// keyboard.
     fn keys_down(&self) -> Vec<Key>;
 }
 
-/// Stores the registers, memory, timers, and any other data necessary to run the interpreter
+/// Stores the registers, memory, timers, and any other data necessary to run the interpreter.
+///
+/// # Examples
+///
+/// ```no_run
+/// # use std::io::Error;
+/// # use chipotle8::Interpreter;
+/// # fn main() -> Result<(), Error> {
+/// let mut interpreter = Interpreter::with_game_file("data/PONG")?;
+///
+/// // execute the first two instructions of the `PONG` game
+/// interpreter.cycle();
+/// interpreter.cycle();
+/// #    Ok(())
+/// # }
 pub struct Interpreter {
     memory: [u8; 4096], // 4k of RAM
 
@@ -170,7 +222,7 @@ impl Interpreter {
     /// called on it to load in the game file.
     ///
     /// Note: `Into` trick allows passing `Logger` directly, without the `Some` part.
-    /// See http://xion.io/post/code/rust-optional-args.html
+    /// See http://xion.io/post/code/rust-optional-args.html.
     fn new<L: Into<Option<slog::Logger>>>(logger: L) -> Self {
         let log = logger.into().unwrap_or({
             let mut builder = TerminalLoggerBuilder::new();
@@ -237,14 +289,44 @@ impl Interpreter {
         interpreter
     }
 
-    /// Creates an Interpreter with an optional Logger and a path to a CHIP-8 game file.
+    /// Creates an Interpreter with a path to a CHIP-8 game file.
     ///
-    /// Note: `Into` trick allows passing `Logger` directly, without the `Some` part.
-    /// See http://xion.io/post/code/rust-optional-args.html
-    pub fn with_game_file<L: Into<Option<slog::Logger>>>(
-        logger: L,
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::io::Error;
+    /// # use chipotle8::Interpreter;
+    /// # fn main() -> Result<(), Error> {
+    /// let mut interpreter = Interpreter::with_game_file("data/PONG")?;
+    ///
+    /// # Ok(())
+    /// # }
+    pub fn with_game_file(
         path_to_game_file: &str,
     ) -> Result<Self, Error> {
+        Self::with_game_file_and_logger(path_to_game_file, None)
+    }
+
+    /// Creates an Interpreter with a path to a CHIP-8 game file and an optional logger.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::io::Error;
+    /// # use chipotle8::Interpreter;
+    /// # fn main() -> Result<(), Error> {
+    /// let mut interpreter = Interpreter::with_game_file_and_logger("data/PONG", None)?;
+    ///
+    /// # Ok(())
+    /// # }
+
+    pub fn with_game_file_and_logger<L: Into<Option<slog::Logger>>>(
+        path_to_game_file: &str,
+        logger: L,
+    ) -> Result<Self, Error> {
+        // Note: `Into` trick allows passing `Logger` directly, without the `Some` part.
+        // See http://xion.io/post/code/rust-optional-args.html
+
         let mut interpreter = Interpreter::new(logger);
         let res = interpreter.initialize(path_to_game_file);
         if res.is_ok() {
@@ -252,10 +334,6 @@ impl Interpreter {
         } else {
             Err(res.err().unwrap())
         }
-    }
-
-    pub fn get_logger(&self) -> &Logger {
-        &self.logger
     }
 
     /// Update the state of the interpreter by running the operation
@@ -538,7 +616,7 @@ impl Interpreter {
         self.delay_timer.saturating_sub(num_decrement)
     }
 
-    /// Return the decoded Op at the current program counter. Does not increment the program counter
+    /// Return the decoded Op at the current program counter. Does not increment the program counter.
     fn get_instr_at_pc(&self) -> Op {
         let msb = self.memory[self.pc];
         let lsb = self.memory[self.pc + 1];
@@ -549,7 +627,32 @@ impl Interpreter {
         Op::from(two_u8s_to_u16(msb, lsb))
     }
 
-    /// Update the Interpreter keyboard using the state of the system keyboard
+    /// Update the Interpreter keyboard using the state of the system keyboard.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::io::Error;
+    /// # use chipotle8::{Interpreter, AsKeyboard, Key};
+    /// use device_query::{DeviceQuery, DeviceState, Keycode};
+    ///
+    /// struct Keyboard(pub DeviceState);
+    ///
+    /// impl AsKeyboard for Keyboard {
+    ///     fn keys_down(&self) -> Vec<Key> {
+    ///         // TODO: if this weren't an example we'd actually implement this!
+    ///         vec![Key::Key1]
+    ///     }
+    /// }
+    ///
+    /// fn main() -> Result<(), Error> {
+    ///     let mut interpreter = Interpreter::with_game_file("data/PONG")?;
+    ///
+    ///     let keyboard = Keyboard(DeviceState::new());
+    ///
+    ///     interpreter.handle_key_input(&keyboard);
+    ///     Ok(())
+    /// }
     pub fn handle_key_input(&mut self, keyboard: &impl AsKeyboard) {
         let keys_down = keyboard.keys_down();
 
@@ -562,15 +665,26 @@ impl Interpreter {
     }
 
     /// Skip executing the next instruction by incrementing the program counter 2 bytes. Used
-    /// by some conditional opcodes
+    /// by some conditional opcodes.
     #[inline]
     fn skip_instruction(&mut self) {
         self.pc += 2;
     }
 
-    /// Returns the display pixels with a resolution of 640x320
+    /// Returns the display pixels with a resolution of 640x320.
     ///
-    /// TODO: do not hardcode the ENLARGE_RATIO.
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use std::io::Error;
+    /// # use chipotle8::Interpreter;
+    /// # fn main() -> Result<(), Error> {
+    /// let mut interpreter = Interpreter::with_game_file("data/PONG")?;
+    ///
+    /// // this will return a slice 640x320 of all 0's,
+    /// let display = interpreter.get_pixels();
+    /// #    Ok(())
+    /// # }
     pub fn get_pixels(&mut self) -> &[u32] {
         self.graphics.get_pixels()
     }
@@ -582,6 +696,22 @@ impl Interpreter {
     /// 1. read the instruction at the program counter
     /// 2. decode it
     /// 3. execute it
+    /// 4. possibly advance the program counter
+    /// 5. decrement the sound and delay timers
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use std::io::Error;
+    /// # use chipotle8::Interpreter;
+    /// # fn main() -> Result<(), Error> {
+    /// let mut interpreter = Interpreter::with_game_file("data/PONG")?;
+    ///
+    /// // execute the first two instructions of the `PONG` game
+    /// interpreter.cycle();
+    /// interpreter.cycle();
+    /// #    Ok(())
+    /// # }
     pub fn cycle(&mut self) -> Option<Op> {
         let op = self.get_instr_at_pc();
         if !self.keyboard.is_blocking() {
@@ -641,7 +771,7 @@ impl Interpreter {
     /// Read in a game file and initialize the necessary registers.
     ///
     /// Returns an error if we fail to open the game file
-    pub fn initialize(&mut self, path: &str) -> Result<(), Error> {
+    fn initialize(&mut self, path: &str) -> Result<(), Error> {
         let game_file = File::open(path).unwrap();
 
         self.read_game_file(game_file)?;

--- a/src/op.rs
+++ b/src/op.rs
@@ -1,4 +1,7 @@
-/// 35 CHIP 8 op codes. The u8's are guaranteed to be between 0x0 and 0xF
+/// 35 CHIP 8 op codes. The u8's are guaranteed to be between 0x0 and 0xF.
+///
+/// See [the CHIP-8 Wikipedia page](https://en.wikipedia.org/wiki/CHIP-8#Opcode_table) for details
+/// on each opcode.
 #[derive(Debug, PartialEq, Copy, Clone)]
 pub enum Op {
     // 0XXX
@@ -76,6 +79,17 @@ pub enum Op {
 impl Op {
     /// Return true if this op is related to the display. Later we use
     /// this to decide if we should devote cycles to redrawing the graphics buffer
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use chipotle8::Op;
+    ///
+    /// let op = Op::DispDraw(0x0, 0x0, 0x0);
+    /// assert_eq!(op.is_display_op(), true);
+    ///
+    /// let op = Op::Goto(0x0, 0x0, 0x0);
+    /// assert_eq!(op.is_display_op(), false);
     pub fn is_display_op(&self) -> bool {
         match *self {
             Op::DispDraw(_, _, _) | Op::DispClear => true,


### PR DESCRIPTION
In the process I slightly changed the `Interpreter`'s API so that it can only be created with
`Interpreter::with_game_file` so now it can't be used in an inconsistent state where it's been allocated,
but no game as been loaded. I also got rid of the `bin/` directory and moved to using `example/pong.rs`