### PR TITLE
Add streaming display changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,8 @@ license = "MIT"
 rand = "0.7.3"
 slog = "2.5.2"
 sloggers = "0.3.5"
+serde = { version = "1.0.105", features = ["derive"] }
+serde_json = "1.0.51"
 
 [dev-dependencies]
 minifb = "0.15.3"

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -18,7 +18,7 @@ const WHITE_RGB: u32 = 0x0000_0000;
 const MAX_CHANGES_SIZE: usize = 5_000;
 
 /// Holds the coordinates and state of a recently changed pixel in the display.
-/// With DisplayChange we can return only those pixel which changed to the user, 
+/// With DisplayChange we can return only those pixel which changed to the user,
 /// which is much more performant than returning ALL of the pixel changes through
 /// [`get_pixels`](function.get_pixels.html)
 #[derive(Clone, PartialEq, Debug, Default, Serialize)]
@@ -37,7 +37,7 @@ pub struct Graphics {
     display: Vec<u32>,
 
     // A collection of all the pixel display changes since we last reset the changes
-    changes: Vec<DisplayChange>
+    changes: Vec<DisplayChange>,
 }
 
 impl Graphics {
@@ -83,7 +83,11 @@ impl Graphics {
         }
 
         // we keep a running collection of recent changes to the display, so we must update it
-        self.add_change(DisplayChange { x: x as usize, y: y as usize, is_alive: enabled });
+        self.add_change(DisplayChange {
+            x: x as usize,
+            y: y as usize,
+            is_alive: enabled,
+        });
 
         prev_pix == BLACK_RGB && self.buffer[idx] == WHITE_RGB
     }
@@ -172,17 +176,32 @@ pub mod graphics_tests {
     #[test]
     fn changes() {
         let mut g = Graphics::new();
-        
+
         // artificially set some pixels so we can xor_set them later
         g.xor_set(0, 0, true);
         g.xor_set(0, 1, false);
         g.xor_set(1, 0, false);
 
-        assert_eq!(g.changes, vec![
-            DisplayChange { x: 0, y: 0, is_alive: true }, 
-            DisplayChange { x: 0, y: 1, is_alive: false },
-            DisplayChange { x: 1, y: 0, is_alive: false },
-        ]);
+        assert_eq!(
+            g.changes,
+            vec![
+                DisplayChange {
+                    x: 0,
+                    y: 0,
+                    is_alive: true
+                },
+                DisplayChange {
+                    x: 0,
+                    y: 1,
+                    is_alive: false
+                },
+                DisplayChange {
+                    x: 1,
+                    y: 0,
+                    is_alive: false
+                },
+            ]
+        );
 
         g.flush_changes();
 

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -5,6 +5,7 @@ use std::ops::Index;
 pub const WIDTH: usize = 64;
 pub const HEIGHT: usize = 32;
 pub const ENLARGE_RATIO: usize = 10;
+use serde::Serialize;
 
 const BLACK_RGB: u32 = 0x00FF_FFFF;
 const WHITE_RGB: u32 = 0x0000_0000;
@@ -20,7 +21,7 @@ const MAX_CHANGES_SIZE: usize = 5_000;
 /// With DisplayChange we can return only those pixel which changed to the user, 
 /// which is much more performant than returning ALL of the pixel changes through
 /// [`get_pixels`](function.get_pixels.html)
-#[derive(Clone, PartialEq, Debug, Default)]
+#[derive(Clone, PartialEq, Debug, Default, Serialize)]
 pub struct DisplayChange {
     x: usize,
     y: usize,

--- a/src/lib_test.rs
+++ b/src/lib_test.rs
@@ -32,8 +32,8 @@ pub mod interpreter_tests {
             let op = Op::from(instr);
 
             // set some graphics bits to true so we can later see them set to false;
-            interpreter.graphics.set(0, 0, true);
-            interpreter.graphics.set(
+            interpreter.graphics.xor_set(0, 0, true);
+            interpreter.graphics.xor_set(
                 (graphics::WIDTH - 1) as u8,
                 (graphics::HEIGHT - 1) as u8,
                 true,
@@ -266,13 +266,13 @@ pub mod interpreter_tests {
             let x_usize = x as usize;
             let y_usize = y as usize;
 
-            interpreter.v[x_usize] = 0b11001100;
-            interpreter.v[y_usize] = 0b00110011;
+            interpreter.v[x_usize] = 0b1100_1100;
+            interpreter.v[y_usize] = 0b0011_0011;
 
             interpreter.execute(op);
 
-            assert_eq!(interpreter.v[x_usize], 0b11111111);
-            assert_eq!(interpreter.v[y_usize], 0b00110011)
+            assert_eq!(interpreter.v[x_usize], 0b1111_1111);
+            assert_eq!(interpreter.v[y_usize], 0b0011_0011)
         }
 
         #[test]


### PR DESCRIPTION
Adds a new function `flush_changes` which returns a `Vec<DisplayChanges>` where a `DisplayChange` represents the coordinates of a pixel value and what its new value is.

This allows callers to use a vastly more performant method of getting changes to the interpreter's display pixels, which is needed for networked applications that want to minimize how much data they're serving over the Internet. Now instead of sending the entire display to a user, we can use `flush_changes` to send only those pixels values that changed.